### PR TITLE
Switch to Protobuf for the Arduino to RPi communication

### DIFF
--- a/include/logging.h
+++ b/include/logging.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <ArduinoComm.pb.h>
+#include "Arduino.h"
+
+void sendEventMessage(RocketryProto_EventTypes type);
+void sendEventMessage(RocketryProto_EventTypes type, int32_t data);
+void sendErrorMessage(RocketryProto_ErrorTypes type);
+void sendErrorMessage(RocketryProto_ErrorTypes type, int32_t data);

--- a/include/logging.h
+++ b/include/logging.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <ArduinoComm.pb.h>
 #include "Arduino.h"
+#include <ArduinoComm.pb.h>
 
 void sendEventMessage(RocketryProto_EventTypes type);
 void sendEventMessage(RocketryProto_EventTypes type, int32_t data);

--- a/include/main.h
+++ b/include/main.h
@@ -2,5 +2,8 @@
 #include "ArduinoComm.pb.h"
 #include "Servo.h"
 #include <Arduino.h>
+#include <PacketSerial.h>
+
+extern COBSPacketSerial cobsPacketSerial;
 
 void onPacketReceived(const uint8_t *buffer, size_t size);

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,38 +1,6 @@
 #include <Arduino.h>
 
 template <typename T>
-void serialPrintLn(const T message)
-{
-    Serial.println(message);
-}
-
-template <typename T, typename... Types>
-void serialPrintLn(const T message, Types... otherMessages)
-{
-    Serial.print(message);
-
-    serialPrintLn(otherMessages...);
-}
-
-template <typename... Types>
-void serialInfo(Types... messages)
-{
-    serialPrintLn("INFO: ", messages...);
-}
-
-template <typename... Types>
-void serialWarning(Types... messages)
-{
-    serialPrintLn("WARN: ", messages...);
-}
-
-template <typename... Types>
-void serialError(Types... messages)
-{
-    serialPrintLn("Error: ", messages...);
-}
-
-template <typename T>
 bool arrayContains(const T *array, int size, T element)
 {
     for (int i = 0; i < size; i++)

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ extra_scripts =
     pre:./protobuild.py
 
 ; Disable error messages to reduce RAM usage
-; build_flags =
-;     -DPB_NO_ERRMSG
+build_flags =
+    -DPB_NO_ERRMSG
 
 monitor_speed = 115200

--- a/src/digitalMessage.cpp
+++ b/src/digitalMessage.cpp
@@ -1,6 +1,7 @@
 #include "digitalMessage.h"
 #include "Arduino.h"
 #include "utils.h"
+#include <logging.h>
 
 // Servo Information
 constexpr int maxDigitalPins = 20;
@@ -11,11 +12,11 @@ void controlDigital(uint8_t pin, bool activate)
 {
     if (!arrayContains(enabledDigitalPins, digitalCount, pin))
     {
-        serialPrintLn("Digital pin ", pin, " is not initialized. Ignoring request.");
+        sendErrorMessage(RocketryProto_ErrorTypes_PIN_NOT_INITIALIZED, pin);
         return;
     }
 
-    serialPrintLn("Digital control: pin: ", pin, ", activate: ", activate);
+    sendEventMessage(RocketryProto_EventTypes_DIGITAL_CONTROL, pin);
 
     digitalWrite(pin, activate);
 }
@@ -37,7 +38,7 @@ void initDigital(const RocketryProto_DigitalInit &digitalInit)
         enabledDigitalPins[digitalCount] = pin;
         digitalCount++;
 
-        serialPrintLn("Digital init: pin: ", pin);
+        sendEventMessage(RocketryProto_EventTypes_DIGITAL_INIT, pin);
     }
 }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -2,11 +2,13 @@
 #include "main.h"
 #include <pb_encode.h>
 
-void sendEventMessage(RocketryProto_EventTypes type) {
+void sendEventMessage(RocketryProto_EventTypes type)
+{
     sendEventMessage(type, 0);
 }
 
-void sendEventMessage(RocketryProto_EventTypes type, int32_t data) {
+void sendEventMessage(RocketryProto_EventTypes type, int32_t data)
+{
     RocketryProto_ArduinoOut msg = RocketryProto_ArduinoOut_init_zero;
     msg.which_data = RocketryProto_ArduinoOut_eventMessage_tag;
 
@@ -27,11 +29,13 @@ void sendEventMessage(RocketryProto_EventTypes type, int32_t data) {
     delete[] buf;
 }
 
-void sendErrorMessage(RocketryProto_ErrorTypes type) {
+void sendErrorMessage(RocketryProto_ErrorTypes type)
+{
     sendErrorMessage(type, 0);
 }
 
-void sendErrorMessage(RocketryProto_ErrorTypes type, int32_t data) {
+void sendErrorMessage(RocketryProto_ErrorTypes type, int32_t data)
+{
     RocketryProto_ArduinoOut msg = RocketryProto_ArduinoOut_init_zero;
     msg.which_data = RocketryProto_ArduinoOut_errorMessage_tag;
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,0 +1,53 @@
+#include "logging.h"
+#include "main.h"
+#include <pb_encode.h>
+
+void sendEventMessage(RocketryProto_EventTypes type) {
+    sendEventMessage(type, 0);
+}
+
+void sendEventMessage(RocketryProto_EventTypes type, int32_t data) {
+    RocketryProto_ArduinoOut msg = RocketryProto_ArduinoOut_init_zero;
+    msg.which_data = RocketryProto_ArduinoOut_eventMessage_tag;
+
+    RocketryProto_EventMessage &event = msg.data.eventMessage;
+    event.type = type;
+    event.data = data;
+
+    pb_ostream_t sizestream = {nullptr};
+    pb_encode(&sizestream, RocketryProto_ArduinoOut_fields, &msg);
+
+    auto *buf = new uint8_t[sizestream.bytes_written];
+
+    pb_ostream_t outputStream = pb_ostream_from_buffer(buf, sizestream.bytes_written);
+    pb_encode(&outputStream, RocketryProto_ArduinoOut_fields, &msg);
+
+    cobsPacketSerial.send(buf, sizestream.bytes_written);
+
+    delete[] buf;
+}
+
+void sendErrorMessage(RocketryProto_ErrorTypes type) {
+    sendErrorMessage(type, 0);
+}
+
+void sendErrorMessage(RocketryProto_ErrorTypes type, int32_t data) {
+    RocketryProto_ArduinoOut msg = RocketryProto_ArduinoOut_init_zero;
+    msg.which_data = RocketryProto_ArduinoOut_errorMessage_tag;
+
+    RocketryProto_ErrorMessage &event = msg.data.errorMessage;
+    event.type = type;
+    event.data = data;
+
+    pb_ostream_t sizestream = {nullptr};
+    pb_encode(&sizestream, RocketryProto_ArduinoOut_fields, &msg);
+
+    auto *buf = new uint8_t[sizestream.bytes_written];
+
+    pb_ostream_t outputStream = pb_ostream_from_buffer(buf, sizestream.bytes_written);
+    pb_encode(&outputStream, RocketryProto_ArduinoOut_fields, &msg);
+
+    cobsPacketSerial.send(buf, sizestream.bytes_written);
+
+    delete[] buf;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,9 +3,9 @@
 #include "utils.h"
 #include <Arduino.h>
 #include <ArduinoComm.pb.h>
-#include <PacketSerial.h>
 #include <main.h>
 #include <pb_decode.h>
+#include "logging.h"
 
 COBSPacketSerial cobsPacketSerial;
 
@@ -14,6 +14,8 @@ void setup()
     cobsPacketSerial.begin(57600);
 
     cobsPacketSerial.setPacketHandler(&onPacketReceived);
+
+    sendEventMessage(RocketryProto_EventTypes_RESET);
 }
 
 void loop()
@@ -34,7 +36,7 @@ void onPacketReceived(const uint8_t *buffer, size_t size)
 
     if (!pb_decode(&stream, RocketryProto_ArduinoIn_fields, &message))
     {
-        serialPrintLn("Error decoding message: ", stream.errmsg);
+        sendErrorMessage(RocketryProto_ErrorTypes_DECODE_ERROR);
         return;
     }
 
@@ -56,6 +58,6 @@ void onPacketReceived(const uint8_t *buffer, size_t size)
         resetFunc();
         break;
     default:
-        serialPrintLn("Unknown message type. Ignoring request.");
+        sendErrorMessage(RocketryProto_ErrorTypes_UNKNOWN_MESSAGE);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,11 @@
 #include "digitalMessage.h"
+#include "logging.h"
 #include "servoMessage.h"
 #include "utils.h"
 #include <Arduino.h>
 #include <ArduinoComm.pb.h>
 #include <main.h>
 #include <pb_decode.h>
-#include "logging.h"
 
 COBSPacketSerial cobsPacketSerial;
 

--- a/src/servoMessage.cpp
+++ b/src/servoMessage.cpp
@@ -1,6 +1,7 @@
 #include "servoMessage.h"
 #include "Arduino.h"
 #include "utils.h"
+#include <logging.h>
 
 // Servo Information
 constexpr int maxServoCount = 12;
@@ -27,13 +28,13 @@ void controlServo(uint8_t pin, int position)
 
     if (servo != nullptr)
     {
-        serialPrintLn("Servo control: pin: ", pin, ", position: ", position);
+        sendEventMessage(RocketryProto_EventTypes_SERVO_CONTROL, pin);
 
         servo->servo.write(position);
     }
     else
     {
-        serialPrintLn("Servo ", pin, " is not initialized. Ignoring request.");
+        sendErrorMessage(RocketryProto_ErrorTypes_PIN_NOT_INITIALIZED, pin);
     }
 }
 
@@ -55,7 +56,7 @@ void initServo(const RocketryProto_ServoInit &servoInit)
 
         servoCount++;
 
-        serialPrintLn("Servo init: pin: ", servoInit.pin, ", safePosition:", servoInit.safePosition);
+        sendEventMessage(RocketryProto_EventTypes_SERVO_INIT, servoInit.pin);
     }
 }
 


### PR DESCRIPTION
Use a more space-efficient format for logging on the Arduino. This PR needs to be merged first: https://github.com/uorocketry/protobuf-definitions/pull/1