### PR TITLE
Send the current servo and digital pins state to the RPi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .pio
 lib/RocketryProto/
+
+.idea
+.vscode

--- a/include/digitalMessage.h
+++ b/include/digitalMessage.h
@@ -2,5 +2,12 @@
 
 #include "ArduinoComm.pb.h"
 
+struct DigitalInfo
+{
+    uint8_t pin;
+    bool activated;
+};
+
 void initDigital(const RocketryProto_DigitalInit &message);
 void controlDigital(const RocketryProto_DigitalControl &message);
+void sendDigitalState();

--- a/include/servoMessage.h
+++ b/include/servoMessage.h
@@ -8,7 +8,9 @@ struct ServoInfo
     Servo servo;
     uint8_t pin;
     int safePosition;
+    int currentPosition;
 };
 
 void initServo(const RocketryProto_ServoInit &message);
 void controlServo(const RocketryProto_ServoControl &message);
+void sendServoState();

--- a/src/digitalMessage.cpp
+++ b/src/digitalMessage.cpp
@@ -1,16 +1,35 @@
 #include "digitalMessage.h"
 #include "Arduino.h"
+#include "ArduinoComm.pb.h"
+#include "main.h"
+#include "pb_encode.h"
 #include "utils.h"
 #include <logging.h>
 
 // Servo Information
 constexpr int maxDigitalPins = 20;
-uint8_t enabledDigitalPins[maxDigitalPins];
+DigitalInfo digitalPins[maxDigitalPins];
 uint16_t digitalCount = 0;
+
+DigitalInfo *findDigital(int pin)
+{
+    for (uint16_t i = 0; i < digitalCount; i++)
+    {
+        DigitalInfo &digital = digitalPins[i];
+        if (digital.pin == pin)
+        {
+            return &digital;
+        }
+    }
+
+    return nullptr;
+}
 
 void controlDigital(uint8_t pin, bool activate)
 {
-    if (!arrayContains(enabledDigitalPins, digitalCount, pin))
+    DigitalInfo *digital = findDigital(pin);
+
+    if (digital == nullptr)
     {
         sendErrorMessage(RocketryProto_ErrorTypes_PIN_NOT_INITIALIZED, pin);
         return;
@@ -19,13 +38,14 @@ void controlDigital(uint8_t pin, bool activate)
     sendEventMessage(RocketryProto_EventTypes_DIGITAL_CONTROL, pin);
 
     digitalWrite(pin, activate);
+    digital->activated = activate;
 }
 
 void initDigital(const RocketryProto_DigitalInit &digitalInit)
 {
     uint8_t pin = digitalInit.pin;
 
-    if (!arrayContains(enabledDigitalPins, digitalCount, pin))
+    if (findDigital(pin) == nullptr)
     {
         // Ignore if we don't have any more free servos
         if (maxDigitalPins == digitalCount)
@@ -35,7 +55,8 @@ void initDigital(const RocketryProto_DigitalInit &digitalInit)
 
         pinMode(pin, OUTPUT);
 
-        enabledDigitalPins[digitalCount] = pin;
+        digitalPins[digitalCount].pin = pin;
+        digitalPins[digitalCount].activated = false;
         digitalCount++;
 
         sendEventMessage(RocketryProto_EventTypes_DIGITAL_INIT, pin);
@@ -45,4 +66,31 @@ void initDigital(const RocketryProto_DigitalInit &digitalInit)
 void controlDigital(const RocketryProto_DigitalControl &digitalControl)
 {
     controlDigital(digitalControl.pin, digitalControl.activate);
+}
+
+void sendDigitalState()
+{
+    for (uint16_t i = 0; i < digitalCount; i++)
+    {
+        const DigitalInfo &info = digitalPins[i];
+
+        RocketryProto_ArduinoOut msg = RocketryProto_ArduinoOut_init_zero;
+        msg.which_data = RocketryProto_ArduinoOut_digitalState_tag;
+
+        RocketryProto_DigitalState &state = msg.data.digitalState;
+        state.pin = info.pin;
+        state.activated = info.activated;
+
+        pb_ostream_t sizestream = {nullptr};
+        pb_encode(&sizestream, RocketryProto_ArduinoOut_fields, &msg);
+
+        auto *buf = new uint8_t[sizestream.bytes_written];
+
+        pb_ostream_t outputStream = pb_ostream_from_buffer(buf, sizestream.bytes_written);
+        pb_encode(&outputStream, RocketryProto_ArduinoOut_fields, &msg);
+
+        cobsPacketSerial.send(buf, sizestream.bytes_written);
+
+        delete[] buf;
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include <pb_decode.h>
 
 COBSPacketSerial cobsPacketSerial;
+long lastStateSend = 0;
 
 void setup()
 {
@@ -21,6 +22,13 @@ void setup()
 void loop()
 {
     cobsPacketSerial.update();
+
+    // Send state each second
+    if (millis() - lastStateSend > 1000)
+    {
+        sendServoState();
+        lastStateSend = millis();
+    }
 }
 
 void (*resetFunc)(void) = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ void loop()
     if (millis() - lastStateSend > 1000)
     {
         sendServoState();
+        sendDigitalState();
         lastStateSend = millis();
     }
 }

--- a/src/servoMessage.cpp
+++ b/src/servoMessage.cpp
@@ -1,7 +1,10 @@
 #include "servoMessage.h"
 #include "Arduino.h"
+#include "ArduinoComm.pb.h"
+#include "main.h"
 #include "utils.h"
 #include <logging.h>
+#include <pb_encode.h>
 
 // Servo Information
 constexpr int maxServoCount = 12;
@@ -31,6 +34,7 @@ void controlServo(uint8_t pin, int position)
         sendEventMessage(RocketryProto_EventTypes_SERVO_CONTROL, pin);
 
         servo->servo.write(position);
+        servo->currentPosition = position;
     }
     else
     {
@@ -53,6 +57,7 @@ void initServo(const RocketryProto_ServoInit &servoInit)
         servos[servoCount].pin = static_cast<uint8_t>(servoInit.pin);
         servos[servoCount].safePosition = static_cast<int>(servoInit.safePosition);
         servos[servoCount].servo.attach(servoInit.pin);
+        servos[servoCount].currentPosition = -1;
 
         servoCount++;
 
@@ -63,4 +68,31 @@ void initServo(const RocketryProto_ServoInit &servoInit)
 void controlServo(const RocketryProto_ServoControl &servoControl)
 {
     controlServo(servoControl.pin, servoControl.position);
+}
+
+void sendServoState()
+{
+    for (uint16_t i = 0; i < servoCount; i++)
+    {
+        const ServoInfo &info = servos[i];
+
+        RocketryProto_ArduinoOut msg = RocketryProto_ArduinoOut_init_zero;
+        msg.which_data = RocketryProto_ArduinoOut_servoState_tag;
+
+        RocketryProto_ServoState &state = msg.data.servoState;
+        state.pin = info.pin;
+        state.position = info.currentPosition;
+
+        pb_ostream_t sizestream = {nullptr};
+        pb_encode(&sizestream, RocketryProto_ArduinoOut_fields, &msg);
+
+        auto *buf = new uint8_t[sizestream.bytes_written];
+
+        pb_ostream_t outputStream = pb_ostream_from_buffer(buf, sizestream.bytes_written);
+        pb_encode(&outputStream, RocketryProto_ArduinoOut_fields, &msg);
+
+        cobsPacketSerial.send(buf, sizestream.bytes_written);
+
+        delete[] buf;
+    }
 }


### PR DESCRIPTION
The title says it all. This will be useful when the RPi restarts and the Arduino already has been initialized on some pins.

Also, some may question my decision to send each state in a separate protobuf message. The main reason is that it makes it SO much easier to send separate messages than figuring out how to send it in an array, inside a oneof using nanopb (it might not even be possible).